### PR TITLE
Local dev 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,7 @@ POSTGRES_URL=xxxxxxxxxx
 
 ```bash
 python voice_validation_api/validation_api.py
-
 ```
-
-
 
 #### Running the validator with your own validation API service running locally
 ```bash
@@ -286,6 +283,76 @@ python neurons/model_queue.py --use-local-validation-api
 
 python voice_validation_api/worker_queue.py 
 ```
+
+## Local Development
+
+### Prepare a .env File
+Ensure you have a .env file in the root directory of your project. This file should include the necessary environment variables for the application to function correctly. Below is an example .env file:
+
+```bash
+# Admin credentials
+ADMIN_KEY=example_admin_key
+
+# Supabase credentials
+SUPABASE_KEY=example_supabase_key
+SUPABASE_URL=https://example.supabase.co
+
+# Hugging Face credentials
+HF_ACCESS_TOKEN=hf_example_access_token
+HF_USER=ExampleUser
+DIPPY_KEY=example_dippy_key
+
+# OpenAI API Key
+OPENAI_API_KEY=sk-example_openai_api_key
+
+# Dataset API Key
+DATASET_API_KEY=example_dataset_api_key
+
+POSTGRES_URL=postgresql://vapi:vapi@localhost:5432/vapi # For local dev db spun up by docker
+
+```
+### Spin up services 
+To quickly spin up the model_queue, worker_queue, and validation_api, use the local-compose script. 
+
+```bash
+docker compose -f local-compose.yml up -d --build
+```
+
+### Viewing Logs
+To monitor logs for a specific container, use the following command, replacing "Container name to see logs" with the desired container's name:
+
+
+```bash
+docker logs -f "<Container name to see logs>"
+```
+
+
+### Viewing and Interacting with the Local PostgreSQL Database
+#### 1. Setup SSH Tunnel
+```bash
+ssh -L 5432:localhost:5432 <remote_server_ip>
+```
+
+#### 2. Connect to the Database Using DBeaver
+If you prefer a graphical interface to inspect the database, such as entries in tables:
+
+- Open DBeaver (or any other database client of your choice).
+- Configure a new connection:
+    - Host: localhost
+    - Port: 5432
+    - Database name, username, and password as per the local configuration.
+- Access and query the database contents as needed.
+
+This is only required if you need a tool like DBeaver to examine database contents interactively.
+
+
+
+
+### Notes
+- The setup is configured to test netuid 231 and uses a local database provided by the Docker Compose file.
+
+- Ensure Docker Compose is installed and running on your system before executing the commands.
+
 ## Model Evaluation Criteria
 ### Human Likeness Score
 Models are evaluated on how closely their vocal outputs resemble natural human speech, considering factors such as emotional expression, intonation, pauses, and excitation levels. The more natural and convincingly human the voice sounds, the higher the score.

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -21,12 +21,12 @@ services:
     build:
       context: .
       dockerfile: modelq.Dockerfile
-    network_mode: host
+    network_mode: "host"
     depends_on:
       postgres:
         condition: service_healthy
     environment:
-      POSTGRES_URL: postgresql://vapi:vapi@postgres:5432/vapi
+      POSTGRES_URL: postgresql://vapi:vapi@localhost:5432/vapi
       ADMIN_KEY: impel_intelligence_best_intelligence
     command: [ "--netuid", "231", "--subtensor.network", "test", "--immediate", "--local-validation-api-port", "7777", "--use-local-validation-api" ]
 
@@ -41,15 +41,27 @@ services:
     build:
       context: .
       dockerfile: worker.Dockerfile
+    network_mode: "host"
     depends_on:
       postgres:
         condition: service_healthy
       speech_image:
         condition: service_started # Ensures speechImage is built first
     environment:
-      POSTGRES_URL: postgresql://vapi:vapi@postgres:5432/vapi
-    ports:
-    - '8001:8000'
+      POSTGRES_URL: postgresql://vapi:vapi@localhost:5432/vapi
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+
+  validation_api:
+    build:
+      context: .
+      dockerfile: vapi.Dockerfile
+    network_mode: "host"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_URL: postgresql://vapi:vapi@localhost:5432/vapi
 
 volumes:
   postgres_data: null

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -7,57 +7,49 @@ services:
       PGUSER: vapi
       PGPASSWORD: vapi
       POSTGRES_PASSWORD: vapi
-      # POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+    - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+    - '5432:5432'
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U vapi -d vapi"]
+      test: [ "CMD-SHELL", "pg_isready -U vapi -d vapi" ]
       interval: 5s
       timeout: 5s
       retries: 5
 
-  # vapi:
-  #   build:
-  #     context: .
-  #     dockerfile: dippy_validation_api/vapi.Dockerfile
-  #     args:
-  #       - DEBUG=${DEBUG:-false}
-  #   # command: ["tail","-f","/dev/null"]
-  #   command: >
-  #     sh -c "if [ \"$$DEBUG\" = \"true\" ]; then 
-  #       python -m jurigged -v /app/dippy_validation_api/validation_api.py --queues 0 --main-api-port 7001;
-  #     else
-  #       python validation_api.py --queues 0 --main-api-port 7001;
-  #     fi"
-  #   environment:
-  #     DATABASE_URL: postgresql://vapi_user:vapi_password@postgres:5432/vapi_db
-  #     DEBUG: ${DEBUG:-false}
-  #     # Jurigged needs this to work in Docker
-  #     PYTHONUNBUFFERED: 1
-  #   volumes:
-  #     - ./dippy_validation_api:/app/dippy_validation_api
-  #     - ./scoring:/app/scoring
-  #     - ./utilities:/app/utilities
-  #     - ./template:/app/template
-  #     - ./model:/app/model
-  #     - ./constants:/app/constants
-  #   ports:
-  #     - "7001:7001"
-  #   env_file:
-  #     - .env
-  #   depends_on:
-  #     postgres:
-  #       condition: service_healthy
+  model_queue:
+    build:
+      context: .
+      dockerfile: modelq.Dockerfile
+    network_mode: host
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_URL: postgresql://vapi:vapi@postgres:5432/vapi
+      ADMIN_KEY: impel_intelligence_best_intelligence
+    command: [ "--netuid", "231", "--subtensor.network", "test", "--immediate", "--local-validation-api-port", "7777", "--use-local-validation-api" ]
 
-  # model_q:
-  #   build:
-  #     context: .
-  #     dockerfile: modelq.Dockerfile
-  #   command: ["python","model_queue.py","--subtensor.network", "test"]
-  #   env_file:
-  #     - .env
+  speech_image:
+    build:
+      context: .
+      dockerfile: evaluator.Dockerfile
+    image: speech
+    entrypoint: [ "/bin/true" ]
+
+  worker_queue:
+    build:
+      context: .
+      dockerfile: worker.Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+      speech_image:
+        condition: service_started # Ensures speechImage is built first
+    environment:
+      POSTGRES_URL: postgresql://vapi:vapi@postgres:5432/vapi
+    ports:
+    - '8001:8000'
 
 volumes:
-  postgres_data:
+  postgres_data: null

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -25,9 +25,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    environment:
-      POSTGRES_URL: postgresql://vapi:vapi@localhost:5432/vapi
-      ADMIN_KEY: impel_intelligence_best_intelligence
+    env_file:
+    - .env
     command: [ "--netuid", "231", "--subtensor.network", "test", "--immediate", "--local-validation-api-port", "7777", "--use-local-validation-api" ]
 
   speech_image:
@@ -47,8 +46,8 @@ services:
         condition: service_healthy
       speech_image:
         condition: service_started # Ensures speechImage is built first
-    environment:
-      POSTGRES_URL: postgresql://vapi:vapi@localhost:5432/vapi
+    env_file:
+    - .env
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
 
@@ -60,8 +59,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    environment:
-      POSTGRES_URL: postgresql://vapi:vapi@localhost:5432/vapi
+    env_file:
+    - .env
 
 volumes:
   postgres_data: null

--- a/modelq.Dockerfile
+++ b/modelq.Dockerfile
@@ -25,6 +25,6 @@ RUN uv pip install -e .
 
 COPY neurons/model_queue.py .
 
-CMD ["python", "model_queue.py"]
+ENTRYPOINT ["python", "model_queue.py"]
 
 

--- a/neurons/model_queue.py
+++ b/neurons/model_queue.py
@@ -97,9 +97,10 @@ class ModelQueue:
         config = ModelQueue.config()
 
         self.config = config
-        self.netuid = self.config.netuid or 231
-        # network = self.config.subtensor.network or "test"
-        network = "test"
+        self.netuid = self.config.netuid or 58
+
+        network = self.config.subtensor.network or "finney"
+
         self.subtensor = Subtensor(network)
 
         self.metagraph = Metagraph(netuid=self.netuid, network=network, lite=True, sync=True)

--- a/neurons/model_queue.py
+++ b/neurons/model_queue.py
@@ -16,83 +16,56 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import asyncio
-from dataclasses import dataclass
-import datetime as dt
-import time
+
 import argparse
-import requests
-import aiohttp
-from asyncio import Semaphore
+import asyncio
+import datetime as dt
 
-
-import math
+import logging
+import os
+import time
 import typing
-import constants
-import traceback
-import bittensor as bt
-
+from asyncio import Semaphore
+from dataclasses import dataclass
 from typing import Dict, Optional
 
-from common.scores import StatusEnum, Scores
-from common.model_id import ModelId
-from common.validation_utils import LocalMetadata
-import os
-
-from common.event_logger import EventLogger
-from bittensor.core.subtensor import Subtensor
+import aiohttp
+import bittensor as bt
 from bittensor.core.metagraph import Metagraph
+from bittensor.core.subtensor import Subtensor
 from dotenv import load_dotenv
 
+import constants
+from common.event_logger import EventLogger
+from common.model_id import ModelId
+from common.scores import Scores, StatusEnum
+from common.validation_utils import LocalMetadata
+
 # Load environment variables from a .env file
-load_dotenv()
+load_dotenv(override=True)
 
 l = LocalMetadata(commit="x", btversion="x")
 
+logger = logging.getLogger("uvicorn")
+logging.basicConfig(level=logging.ERROR)
 
-def push_minerboard(
-    hash: str,
-    uid: int,
-    hotkey: str,
-    block: int,
-    config,
-    local_metadata: LocalMetadata,
-    retryWithRemote: bool = False,
-) -> None:
-    if config.use_local_validation_api and not retryWithRemote:
-        validation_endpoint = f"http://localhost:{config.local_validation_api_port}/minerboard_update"
-    else:
-        validation_endpoint = f"{constants.VALIDATION_SERVER}/minerboard_update"
+# Check for mandatory ADMIN_KEY
+admin_key = os.environ.get("ADMIN_KEY")
+if not admin_key:
+    logger.error(
+        "Critical Error: Environment variable ADMIN_KEY is not set. "
+        "Please ensure a .env file exists and defines ADMIN_KEY with the appropriate key."
+    )
+    raise RuntimeError(
+        "Environment variable ADMIN_KEY is missing. Refer to the documentation to configure your .env file."
+    )
 
-    # Construct the payload with the model name and chat template type
-    payload = {
-        "hash": hash,
-        "uid": uid,
-        "hotkey": hotkey,
-        "block": block,
-    }
-
-    headers = {
-        "Git-Commit": str(local_metadata.commit),
-        "Bittensor-Version": str(local_metadata.btversion),
-        "UID": str(local_metadata.uid),
-        "Hotkey": str(local_metadata.hotkey),
-        "Coldkey": str(local_metadata.coldkey),
-    }
-    if os.environ.get("ADMIN_KEY", None) not in [None, ""]:
-        payload["admin_key"] = os.environ["ADMIN_KEY"]
-
-    # Make the POST request to the validation endpoint
-    try:
-        response = requests.post(validation_endpoint, json=payload, headers=headers)
-        response.raise_for_status()  # Raise an exception for HTTP errors
-    except Exception as e:
-        print(e)
 
 @dataclass
 class MinerInfo:
     hotkey: str
     metadata: Optional[Dict] = None
+
 
 class ModelQueue:
     @staticmethod
@@ -122,16 +95,16 @@ class ModelQueue:
 
     def __init__(self):
         config = ModelQueue.config()
-        
+
         self.config = config
-        self.netuid = self.config.netuid or 58
+        self.netuid = self.config.netuid or 231
         # network = self.config.subtensor.network or "test"
-        network = "finney"
+        network = "test"
         self.subtensor = Subtensor(network)
-        
+
         self.metagraph = Metagraph(netuid=self.netuid, network=network, lite=True, sync=True)
         self.metagraph.sync(subtensor=self.subtensor)
-        
+
         logfilepath = "/tmp/modelq/{time:UNIX}.log"
         self.logger = EventLogger(
             filepath=logfilepath,
@@ -152,13 +125,15 @@ class ModelQueue:
             self.logger.info(f"sleeping for {sleep_time}")
             if not self.config.immediate:
                 time.sleep(sleep_time)
-            
+
             try:
                 asyncio.run(self.load_latest_metagraph())
             except Exception as e:
                 self.logger.error(f"failed to queue {e}")
 
-    async def check_uid(self, uid: int, miner_info_map: typing.Dict[int, MinerInfo], semaphore: Semaphore) -> StatusEnum:
+    async def check_uid(
+        self, uid: int, miner_info_map: typing.Dict[int, MinerInfo], semaphore: Semaphore
+    ) -> StatusEnum:
         async with semaphore:  # Limit concurrent executions
             try:
                 miner_info = miner_info_map[uid]
@@ -167,7 +142,7 @@ class ModelQueue:
                 if metadata is None or "model_id" not in metadata:
                     self.logger.info(f"NO_METADATA : uid: {uid} hotkey : {hotkey}")
                     return StatusEnum.NO_METADATA
-                    
+
                 model_id = metadata["model_id"]
                 block = metadata["block"]
                 result = await self.ensure_model(
@@ -182,7 +157,7 @@ class ModelQueue:
                 )
                 stats = f"{result.status} : uid: {uid} hotkey : {hotkey} block: {block} model_metadata : {model_id}"
                 self.logger.info(stats)
-                
+
                 await self.push_minerboard(
                     hash=model_id.hash,
                     uid=uid,
@@ -192,9 +167,9 @@ class ModelQueue:
                     config=self.config,
                     retryWithRemote=True,
                 )
-                
+
                 return result.status
-                
+
             except Exception as e:
                 self.logger.error(f"exception for uid {uid} : {e}")
                 return StatusEnum.ERROR
@@ -209,7 +184,7 @@ class ModelQueue:
             self.logger.info("empty metagraph")
             return
         hotkeys = latest_metagraph.hotkeys
-        
+
         # Create mapping of uid -> MinerInfo
         miner_info_map: Dict[int, MinerInfo] = {}
         for uid in all_uids:
@@ -217,8 +192,8 @@ class ModelQueue:
             try:
                 metadata = bt.core.extrinsics.serving.get_metadata(self.subtensor, self.netuid, hotkey)
                 if not metadata:
-                    raise RuntimeError(f"no metadata exists for {uid}") 
-                
+                    raise RuntimeError(f"no metadata exists for {uid}")
+
                 commitment = metadata["info"]["fields"][0]
                 hex_data = commitment[list(commitment.keys())[0]][2:]
                 chain_str = bytes.fromhex(hex_data).decode()
@@ -233,19 +208,19 @@ class ModelQueue:
                 print(f"could not fetch data for uid {uid}")
 
         queued = failed = no_metadata = completed = error = running = precheck = 0
-        
+
         # Create semaphore to limit concurrent tasks
         semaphore = Semaphore(max_tasks)
-        
+
         # Create tasks with semaphore
         tasks = [self.check_uid(uid, miner_info_map, semaphore) for uid in all_uids]
         results = await asyncio.gather(*tasks)
-            
+
         for status in results:
             if status == StatusEnum.QUEUED:
                 queued += 1
             elif status == StatusEnum.FAILED:
-                failed += 1 
+                failed += 1
             elif status == StatusEnum.NO_METADATA:
                 no_metadata += 1
             elif status == StatusEnum.COMPLETED:
@@ -256,11 +231,11 @@ class ModelQueue:
                 running += 1
             elif status == StatusEnum.PRECHECK:
                 precheck += 1
-            
+
         self.logger.info(
             f"Status counts:\n"
             f"NO_METADATA: {no_metadata}\n"
-            f"QUEUED: {queued}\n" 
+            f"QUEUED: {queued}\n"
             f"FAILED: {failed}\n"
             f"COMPLETED: {completed}\n"
             f"ERROR: {error}\n"
@@ -280,7 +255,7 @@ class ModelQueue:
         config,
         retryWithRemote: bool = False,
     ) -> Scores:
-        if config.use_local_validation_api and not retryWithRemote:
+        if config.use_local_validation_api and retryWithRemote:
             validation_endpoint = f"http://localhost:{config.local_validation_api_port}/ensure_model"
         else:
             validation_endpoint = f"{constants.VALIDATION_SERVER}/ensure_model"
@@ -327,7 +302,7 @@ class ModelQueue:
         local_metadata: LocalMetadata,
         retryWithRemote: bool = False,
     ) -> None:
-        if config.use_local_validation_api and not retryWithRemote:
+        if config.use_local_validation_api and retryWithRemote:
             validation_endpoint = f"http://localhost:{config.local_validation_api_port}/minerboard_update"
         else:
             validation_endpoint = f"{constants.VALIDATION_SERVER}/minerboard_update"

--- a/vapi.Dockerfile
+++ b/vapi.Dockerfile
@@ -28,4 +28,4 @@ RUN uv pip install -e .
 
 COPY voice_validation_api/validation_api.py .
 
-CMD ["python", "validation_api.py"]
+ENTRYPOINT ["python", "validation_api.py"]

--- a/vapi.Dockerfile
+++ b/vapi.Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.12
+COPY --from=ghcr.io/astral-sh/uv:0.4 /uv /bin/uv
+ENV UV_SYSTEM_PYTHON=1
+WORKDIR /app
+#
+# Install git and git-lfs
+RUN apt-get update && apt-get install -y git git-lfs && rm -rf /var/lib/apt/lists/*
+
+# Initialize git-lfs
+RUN git lfs install
+
+## Copy the requirements file into the container
+COPY requirements.api.txt requirements.txt
+
+RUN uv pip install -r requirements.txt
+
+COPY voice_validation_api ./voice_validation_api
+COPY scoring ./scoring
+COPY utilities ./utilities
+COPY common ./common
+COPY constants ./constants
+# Required for self installing module
+COPY .env .
+COPY README.md .
+COPY pyproject.toml .
+COPY .git .git
+RUN uv pip install -e .
+
+COPY voice_validation_api/validation_api.py .
+
+CMD ["python", "validation_api.py"]


### PR DESCRIPTION
Created a local Docker Compose file to streamline development by automatically spinning up the worker queue, model queue, validation API, and PostgreSQL database. This setup is configured to connect to netuid 231 on the testnet, eliminating the need to run multiple Docker containers manually.

Set up an SSH tunnel to forward the database connection from a remote server to your local machine:"
```
ssh -L 5432:localhost:5432 <ip of machine>
```      
Connect dbeaver to access test db to entries in tables only required if you want to use something like dbeaver to look at the db contents


Run Docker Compose to spin up modelq, workerq, and validation api
```
docker compose -f local-compose.yml up -d --build
```

See logs per container:
```
docker logs -f "Container name to see logs"
```

Points to  netuid 231, test net , and local db
